### PR TITLE
less error prone conda installation

### DIFF
--- a/conda_create_environment.sh
+++ b/conda_create_environment.sh
@@ -1,11 +1,2 @@
 #!/bin/bash
-conda create -y -n dcase2019 python=3.6
-source activate dcase2019
-conda install -y pandas h5py scipy
-conda install -y pytorch torchvision cudatoolkit=9.0 -c pytorch # for gpu install (or cpu in MAC)
-# conda install pytorch-cpu torchvision-cpu -c pytorch (cpu linux)
-conda install -y pysoundfile librosa youtube-dl tqdm -c conda-forge
-conda install -y ffmpeg -c conda-forge
-
-pip install dcase_util
-pip install sed-eval
+conda env create --prefix ./env -f environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+name: dcase2019
+channels:
+  - pytorch
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.8
+  - cudatoolkit=11.3
+  - pandas
+  - h5py
+  - scipy
+  - ffmpeg
+  - torchvision
+  - pytorch
+  - torchaudio=0.10.1
+  - pysoundfile
+  - librosa
+  - youtube-dl
+  - tqdm
+  - pip
+  - pip:
+    - dcase_util
+    - sed-eval


### PR DESCRIPTION
Hi,

thank you for releasing the repo and the conda installation script.

In this PR, I moved the installation script to environment.yml and provided an example command how to use it in local conda environment.

### Why?
I wanted to create my own environment with different name and mistyped the name for the row `source activate dcase2019`, the sourcing command failed because of it and then all the commands were executed in different conda environment. The shell source command did not failed because not `set -e` flag was not set in the bash script and the bash script continued executing.

I rewrote the script to conda environment.yml since it is cleaner way how to install conda packages.
